### PR TITLE
fix usage of posargs in pr

### DIFF
--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -50,5 +50,6 @@ jobs:
       tox-version: ${{ inputs.tox-version }}
       working-directory: ${{ inputs.working-directory }}
       snapcraft: false
+      posargs: ${{ inputs.posargs }}
       juju-env: true
       provider: ${{ inputs.provider }}

--- a/.github/workflows/snap-pull-request.yaml
+++ b/.github/workflows/snap-pull-request.yaml
@@ -54,6 +54,7 @@ jobs:
       tox-version: ${{ inputs.tox-version }}
       working-directory: ${{ inputs.working-directory }}
       snapcraft: true
+      posargs: ${{ inputs.posargs }}
       juju-env: ${{ inputs.juju-env }}
       provider: ${{ inputs.provider }}
 


### PR DESCRIPTION
We forgot to pass pasargs to _pull_request.yaml workflow.