### PR TITLE
checkout also submoduels

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -26,8 +26,9 @@ jobs:
     name: Release to CharmHub
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Download Artifact
         if: ${{ inputs.artifact != '' }}
         id: download_artifact

--- a/.github/workflows/_func.yaml
+++ b/.github/workflows/_func.yaml
@@ -50,6 +50,8 @@ jobs:
         posargs: ${{ fromJson(inputs.posargs) }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/_lint-unit.yaml
+++ b/.github/workflows/_lint-unit.yaml
@@ -29,6 +29,8 @@ jobs:
         python-version: ${{ fromJson(inputs.python-version) }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
There are couple of places where we need to checkout also all submodules, so I think we could use it by default.

[Example](https://github.com/canonical/charm-prometheus-juju-exporter/pull/24) where we need it.