### PR TITLE
drop posargs and use commands

### DIFF
--- a/.github/workflows/_func.yaml
+++ b/.github/workflows/_func.yaml
@@ -23,12 +23,18 @@ on:
         description: "Flag if snap is tested."
         type: boolean
         default: false
-      posargs:
+      commands:
         required: false
         description: |
-          "Optional postargs for `tox -e func -- <postargs>`, e.g. '--series jammy'"
+          Command to run functional test in strategies. It defaults to
+          `make functional`, but is defined as a list, so `['make functional']`.
+          This allows you to run multiple tests with different parameters.
+          Examples:
+          - ['FUNC_ARGS="--series jammy" make functional',
+             'FUNC_ARGS="--series focal" make functional']
+          - ['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']
         type: string
-        default: "['']"  # empty string as default so func test is run at least one
+        default: "['make functional']"
       # actions-operator
       juju-env:
         required: false
@@ -47,7 +53,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        posargs: ${{ fromJson(inputs.posargs) }}
+        command: ${{ fromJson(inputs.commands) }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -69,6 +75,6 @@ jobs:
       - name: Install snapcraft
         if: ${{ inputs.snapcraft }}
         run: sudo snap install snapcraft --classic
-      - name: Run tests with `${{ matrix.posargs }}` posargs
+      - name: Run tests with `${{ matrix.command }}`
         working-directory: ${{ inputs.working-directory }}
-        run: tox -e func -- -sv ${{ matrix.posargs }}
+        run: ${{ matrix.command }}

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -26,12 +26,18 @@ on:
         description: "Flag if snap is tested."
         type: boolean
         default: false
-      posargs:
+      commands:
         required: false
         description: |
-          "Optional postargs for `tox -e func -- <postargs>`, e.g. '--series jammy'"
+          Command to run functional test in strategies. It defaults to
+          `make functional`, but is defined as a list, so `['make functional']`.
+          This allows you to run multiple tests with different parameters.
+          Examples:
+          - ['FUNC_ARGS="--series jammy" make functional',
+             'FUNC_ARGS="--series focal" make functional']
+          - ['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']
         type: string
-        default: "['']"  # empty string as default so func test is run at least one
+        default: "['make functional']"
       # actions-operator
       juju-env:
         required: true
@@ -75,6 +81,6 @@ jobs:
       tox-version: ${{ inputs.tox-version }}
       working-directory: ${{ inputs.working-directory }}
       snapcraft: ${{ inputs.snapcraft }}
-      posargs: ${{ inputs.posargs }}
+      commands: ${{ inputs.commands }}
       juju-env: ${{ inputs.juju-env }}
       provider: ${{ inputs.provider }}

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -23,12 +23,18 @@ on:
         description: "To change working directory"
         type: string
         default: "."
-      posargs:
+      commands:
         required: false
         description: |
-          "Optional postargs for `tox -e func -- <postargs>`, e.g. '--series jammy'"
+          Command to run functional test in strategies. It defaults to
+          `make functional`, but is defined as a list, so `['make functional']`.
+          This allows you to run multiple tests with different parameters.
+          Examples:
+          - ['FUNC_ARGS="--series jammy" make functional',
+             'FUNC_ARGS="--series focal" make functional']
+          - ['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']
         type: string
-        default: "['--series jammy']"
+        default: "['FUNC_ARGS="--series jammy" make functional']"
       # actions-operator
       provider:
         required: false
@@ -50,6 +56,6 @@ jobs:
       tox-version: ${{ inputs.tox-version }}
       working-directory: ${{ inputs.working-directory }}
       snapcraft: false
-      posargs: ${{ inputs.posargs }}
+      commands: ${{ inputs.commands }}
       juju-env: true
       provider: ${{ inputs.provider }}

--- a/.github/workflows/snap-pull-request.yaml
+++ b/.github/workflows/snap-pull-request.yaml
@@ -23,12 +23,18 @@ on:
         description: "To change working directory"
         type: string
         default: "."
-      posargs:
+      commands:
         required: false
         description: |
-          "Optional postargs for `tox -e func -- <postargs>`, e.g. '--series jammy'"
+          Command to run functional test in strategies. It defaults to
+          `make functional`, but is defined as a list, so `['make functional']`.
+          This allows you to run multiple tests with different parameters.
+          Examples:
+          - ['FUNC_ARGS="--series jammy" make functional',
+             'FUNC_ARGS="--series focal" make functional']
+          - ['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']
         type: string
-        default: "['']"  # empty string as default so func test is run at least one
+        default: "['make functional']"
       # actions-operator
       juju-env:
         required: false
@@ -54,7 +60,7 @@ jobs:
       tox-version: ${{ inputs.tox-version }}
       working-directory: ${{ inputs.working-directory }}
       snapcraft: true
-      posargs: ${{ inputs.posargs }}
+      commands: ${{ inputs.commands }}
       juju-env: ${{ inputs.juju-env }}
       provider: ${{ inputs.provider }}
 

--- a/.github/workflows/test-pull-request.yaml
+++ b/.github/workflows/test-pull-request.yaml
@@ -18,7 +18,7 @@ jobs:
       python-version-func: "3.10"
       tox-version: "<4"
       working-directory: ./tests/test_charm_repo
-      posargs: "['--series jammy']"
+      commands: "['FUNC_ARGS="--series jammy" make functional']"
 
   snap-pr:
     uses: ./.github/workflows/snap-pull-request.yaml


### PR DESCRIPTION
We used `tox` to run functional tests, but in snap we are using `TEST_SNAP` often and this is configured in Makefile, so running functional test with `make functional` is much more easy to use in multiple projects.   