### PR TITLE
enable nested containers

### DIFF
--- a/.github/workflows/_func.yaml
+++ b/.github/workflows/_func.yaml
@@ -40,6 +40,10 @@ on:
         required: false
         type: string
         default: "lxd"
+      nested-containers:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   func:
@@ -66,6 +70,11 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ inputs.provider }}
+      - name: Enabled nested LXD containers
+        if: ${{ inputs.provider == 'lxd' && inputs.nested-containers }}
+        run: |
+          lxc profile set default security.nesting=true
+          lxc profile set default security.privileged=true
       - name: Remove tox install by actions-operator
         run: sudo apt remove tox -y
       - name: Install snapcraft

--- a/.github/workflows/_func.yaml
+++ b/.github/workflows/_func.yaml
@@ -74,7 +74,6 @@ jobs:
         if: ${{ inputs.provider == 'lxd' && inputs.nested-containers }}
         run: |
           lxc profile set default security.nesting=true
-          lxc profile set default security.privileged=true
       - name: Remove tox install by actions-operator
         run: sudo apt remove tox -y
       - name: Install snapcraft

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -45,6 +45,10 @@ on:
         required: false
         type: string
         default: "lxd"
+      nested-containers:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   lint-unit:
@@ -82,3 +86,4 @@ jobs:
       snapcraft: ${{ inputs.snapcraft }}
       commands: ${{ inputs.commands }}
       provider: ${{ inputs.provider }}
+      nested-containers: ${{ inputs.nested-containers }}

--- a/.github/workflows/repo-configuration.yaml
+++ b/.github/workflows/repo-configuration.yaml
@@ -7,6 +7,7 @@ on:
         description: "Your personal GitHub Token to trigger configuration"
         type: string
         required: true
+
 jobs:
   configure-all-repos:
     name: Sync repository settings

--- a/.github/workflows/test-func.yaml
+++ b/.github/workflows/test-func.yaml
@@ -17,6 +17,7 @@ jobs:
       working-directory: ./tests/test_charm_repo
       commands: "['FUNC_ARGS=\"--series jammy\" make functional']"
       provider: "lxd"
+      nested-containers: true
 
   snap-func:
     uses: ./.github/workflows/_func.yaml


### PR DESCRIPTION
There some charms which needs to run functional tests on top of nested LXD containerizes. That why we need this future.
Example: https://github.com/canonical/charm-prometheus-juju-exporter