### PR TITLE
Make `commands` a required input and remove its default value

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -29,17 +29,17 @@ on:
         type: boolean
         default: false
       commands:
-        required: false
+        required: true
         description: |
-          Command to run functional test in strategies. It defaults to
-          `make functional`, but is defined as a list, so `['make functional']`.
-          This allows you to run multiple tests with different parameters.
+          Command to run functional test in strategies. It accepts a stringified list
+          of commands, which allows you to run multiple tests with different parameters.
+          This is a required input field.
           Examples:
-          - ['FUNC_ARGS="--series jammy" make functional',
-             'FUNC_ARGS="--series focal" make functional']
-          - ['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']
+          - "['make functional']"
+          - "['FUNC_ARGS="--series jammy" make functional',
+             'FUNC_ARGS="--series focal" make functional']"
+          - "['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']"
         type: string
-        default: "['make functional']"
       # actions-operator
       provider:
         required: false

--- a/.github/workflows/test-pull-request.yaml
+++ b/.github/workflows/test-pull-request.yaml
@@ -29,3 +29,4 @@ jobs:
       tox-version: "<4"
       working-directory: ./tests/test_snap_repo
       snapcraft: true
+      commands: "['make functional']"


### PR DESCRIPTION
Since different charms/snaps have different ways of calling functional tests with commands, after discussion, we decided to make `commands` a required input field and define its values in charm/snap's templates. This change should not break any existing CI since we are already passing `commands` values in templates.