### PR TITLE
Add optional timeout-minutes input

### DIFF
--- a/.github/workflows/_func.yaml
+++ b/.github/workflows/_func.yaml
@@ -18,6 +18,11 @@ on:
         description: "To change working directory"
         type: string
         default: "."
+      timeout-minutes:
+        required: false
+        description: "Configurable timeout limit for functional test job"
+        type: number
+        default: 60
       snapcraft:
         required: false
         description: "Flag if snap is tested."
@@ -49,7 +54,7 @@ jobs:
   func:
     name: Functional tests
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -28,6 +28,11 @@ on:
         description: "Flag if snap is tested."
         type: boolean
         default: false
+      timeout-minutes:
+        required: false
+        description: "Configurable timeout limit for functional test job"
+        type: number
+        default: 60
       commands:
         required: false
         description: |
@@ -83,6 +88,7 @@ jobs:
       python-version: ${{ inputs.python-version-func }}
       tox-version: ${{ inputs.tox-version }}
       working-directory: ${{ inputs.working-directory }}
+      timeout-minutes: ${{ inputs.timeout-minutes }}
       snapcraft: ${{ inputs.snapcraft }}
       commands: ${{ inputs.commands }}
       provider: ${{ inputs.provider }}

--- a/.github/workflows/test-func.yaml
+++ b/.github/workflows/test-func.yaml
@@ -16,6 +16,7 @@ jobs:
       tox-version: "<4"
       working-directory: ./tests/test_charm_repo
       commands: "['FUNC_ARGS=\"--series jammy\" make functional']"
+      timeout-minutes: 120
       provider: "lxd"
       nested-containers: true
 


### PR DESCRIPTION
Parameterize `timeout-minutes` as an optional input so individual repos can define an increased value if necessary.