### PR TITLE
Fix sonar

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -2,6 +2,11 @@ name: SonarCloud
 
 on:
   workflow_call:
+    inputs:
+      workflow-name:
+        required: true
+        description: "The name of the workflow that triggers sonar scan"
+        type: string
 
 jobs:
   sonarcloud:
@@ -15,7 +20,7 @@ jobs:
         if: github.event.workflow_run.event == 'pull_request'
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: CI Setup
+          workflow: ${{ inputs.workflow-name }}
           run_id: ${{ github.event.workflow_run.id }}
           name: PR_NUMBER
       - name: Read PR_NUMBER.txt
@@ -74,7 +79,7 @@ jobs:
         working-directory: .
         run: |
             mkdir tests/unit/report
-            cp cov.xml tests/unit/report/coverage.xml
+            cp coverage.xml tests/unit/report/coverage.xml
       - name: SonarCloud Scan on PR
         if: github.event.workflow_run.event == 'pull_request'
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/test-sonar.yaml
+++ b/.github/workflows/test-sonar.yaml
@@ -1,10 +1,13 @@
 name: SonarCloud
 on:
   workflow_run:
-    workflows: [PR workflow running lint checkers, unit and functional tests]
+    workflows: 
+      - Test for PR workflow
     types: [completed]
 
 jobs:
   sonar:
     uses: ./.github/workflows/sonar.yaml
     secrets: inherit
+    with:
+      workflow-name: Test for PR workflow


### PR DESCRIPTION
Fixes the currently broken sonar workflow. The problems were:
1. The coverage report name produced by _lint-unit.yaml is `coverage.xml`, not `cov.xml`
2. The sonar.yaml was using a fixed name (`CI Setup`) for the triggering workflow, instead of reading it dynamically from the original repo

This PR addresses these problems and also changed the testing file accordingly. 

Note: the changes in test-sonar.yaml file will not take effect until they land in the default branch