### PR TITLE
Remove trigger on approval and fix workflow not triggering on PR merges

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -59,12 +59,6 @@ jobs:
   lint-unit:
     name: Lint checkers and unit tests
     uses: ./.github/workflows/_lint-unit.yaml
-    # Note(rgildein): Lint checkers and unit tests should be triggered on any pull requested,
-    # approval pull request, review was submitted or review comment with recheck.
-    if: |
-      contains(fromJson('["main", "master"]'), github.ref_name) ||
-      github.event_name == 'pull_request' ||
-      github.event.review.body == 'recheck'
     secrets: inherit
     with:
       python-version: ${{ inputs.python-version-unit }}
@@ -75,12 +69,6 @@ jobs:
     uses: ./.github/workflows/_func.yaml
     needs: 
     - lint-unit
-    # Note(rgildein): Functional tests should be triggered only for commits to
-    # master/main branch, if PR was approved or review comment with recheck
-    if: |
-      contains(fromJson('["main", "master"]'), github.ref_name) ||
-      github.event_name == 'pull_request' ||
-      github.event.review.body == 'recheck'
     secrets: inherit
     with:
       python-version: ${{ inputs.python-version-func }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -62,8 +62,8 @@ jobs:
     # Note(rgildein): Lint checkers and unit tests should be triggered on any pull requested,
     # approval pull request, review was submitted or review comment with recheck.
     if: |
+      contains(fromJson('["main", "master"]'), github.ref_name) ||
       github.event_name == 'pull_request' ||
-      github.event.review.state == 'approved' ||
       github.event.review.body == 'recheck'
     secrets: inherit
     with:
@@ -78,8 +78,8 @@ jobs:
     # Note(rgildein): Functional tests should be triggered only for commits to
     # master/main branch, if PR was approved or review comment with recheck
     if: |
-      contains(fromJson('["main", "master"]'), github.event.ref_name) ||
-      github.event.review.state == 'approved' ||
+      contains(fromJson('["main", "master"]'), github.ref_name) ||
+      github.event_name == 'pull_request' ||
       github.event.review.body == 'recheck'
     secrets: inherit
     with:

--- a/.github/workflows/test-pull-request.yaml
+++ b/.github/workflows/test-pull-request.yaml
@@ -6,8 +6,9 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
     branches: [ master, main ]
-  pull_request_review:
-    types: [ submitted ]
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
 
 jobs:
   charm-pr:


### PR DESCRIPTION
To prevent workflows running when there's no changes, we decided to remove the `approval` review as a triggering condition. With this PR, workflows will only be triggered when a PR is opened or updated, a review comment with `recheck` as its content is submitted, or changes to the default branch (either `master` or `main`) are pushed.

This PR also changed `github.event.ref_name` to `github.ref` to get the branch name because the former doesn't exist. 

closes: #19 