### PR TITLE
Add snap build and release workflow

### DIFF
--- a/.github/workflows/_func.yaml
+++ b/.github/workflows/_func.yaml
@@ -20,18 +20,19 @@ on:
         default: "."
       timeout-minutes:
         required: false
-        description: "Configurable timeout limit for functional test job"
+        description: "Configurable timeout limit for functional tests job"
         type: number
         default: 60
       snapcraft:
         required: false
-        description: "Flag if snap is tested."
+        description: |
+          Flag if snap is tested. If set to true, snapcraft will be installed.
         type: boolean
         default: false
       commands:
         required: false
         description: |
-          Command to run functional test in strategies. It defaults to
+          Command to run functional tests in strategies. It defaults to
           `make functional`, but is defined as a list, so `['make functional']`.
           This allows you to run multiple tests with different parameters.
           Examples:

--- a/.github/workflows/_func.yaml
+++ b/.github/workflows/_func.yaml
@@ -10,7 +10,9 @@ on:
         default: "3.10"
       tox-version:
         required: false
-        description: "Tox version, which should be used, e.g. `<4`"
+        description: |
+          Tox version, which should be used, e.g. `<4`. If not specified, the
+          latest version of tox will be installed.
         type: string
         default: ""
       working-directory:

--- a/.github/workflows/_lint-unit.yaml
+++ b/.github/workflows/_lint-unit.yaml
@@ -10,7 +10,9 @@ on:
         default: "['3.10']"
       tox-version:
         required: false
-        description: "Tox version, which should be used, e.g. `<4`"
+        description: |
+          Tox version, which should be used, e.g. `<4`. If not specified, the
+          latest version of tox will be installed.
         type: string
         default: ""
       working-directory:

--- a/.github/workflows/_snap-build.yaml
+++ b/.github/workflows/_snap-build.yaml
@@ -1,0 +1,18 @@
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Snap
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: snapcore/action-build@v1
+        id: build
+      - name: Upload locally built Snap artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: snap-artifact
+          path: ${{ steps.build.outputs.snap }}

--- a/.github/workflows/_snap-release.yaml
+++ b/.github/workflows/_snap-release.yaml
@@ -1,14 +1,19 @@
 on:
   workflow_call:
     inputs:
-      channel:
+      track:
         description: |
-          The channel to which charm should be released. If specified (non-empty string),
-          the snap will be released to the input channel. If kept empty, the channel will
-          be auto-selected base on the current branch. E.g. if the current branch is
-          master or main, the snap will be released to latest/edge; otherwise, the snap will
-          be released to <branch-name>/edge.
-        default: ''
+          The track to which charm should be released. By default, the latest track
+          will be used.
+        default: latest
+        required: false
+        type: string
+      risk-level:
+        description: |
+          The risk level of the channel to which charm should be released. Valid
+          inputs are: edge, beta, candidate, stable. By default, the snap will be
+          released to a channel with "edge" risk level. 
+        default: edge
         required: false
         type: string
   workflow_dispatch:
@@ -25,31 +30,10 @@ jobs:
           name: snap-artifact
       - id: get-snap-name
         run: echo "SNAP_FILE=$(ls *.snap)" >> $GITHUB_OUTPUT
-      - name: Release snap to latest/edge when pushed to the default branch
+      - name: Release snap to the specified channel
         uses: snapcore/action-publish@v1
-        if: |
-          inputs.channel == '' &&
-          contains(fromJSON('["main", "master"]'), github.ref_name)
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
-          release: latest/edge
-      - name: Release to custom channel when pushed to a versioned branch
-        uses: snapcore/action-publish@v1
-        if: |
-          inputs.channel == '' &&
-          contains(fromJSON('["main", "master"]'), github.ref_name) == false
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        with:
-          snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
-          release: ${{ github.ref_name }}/edge
-      - name: Release to custom channel with channel input
-        uses: snapcore/action-publish@v1
-        if: inputs.channel != ''
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-        with:
-          snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
-          release: ${{ inputs.channel }}
+          release: ${{ inputs.track }}/${{ inputs.risk-level }}

--- a/.github/workflows/_snap-release.yaml
+++ b/.github/workflows/_snap-release.yaml
@@ -25,14 +25,6 @@ jobs:
           name: snap-artifact
       - id: get-snap-name
         run: echo "SNAP_FILE=$(ls *.snap)" >> $GITHUB_OUTPUT
-      - env:
-          REF: ${{ github.ref_name }}
-          CHANNEL: ${{ inputs.channel == '' }}
-          BOOL: ${{ contains(fromJSON('["main", "master"]'), github.ref_name) }}
-        run:
-          echo $REF
-          echo $CHANNEL
-          echo $BOOL
       - name: Release snap to latest/edge when pushed to the default branch
         uses: snapcore/action-publish@v1
         if: |

--- a/.github/workflows/_snap-release.yaml
+++ b/.github/workflows/_snap-release.yaml
@@ -1,0 +1,63 @@
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: |
+          The channel to which charm should be released. If specified (non-empty string),
+          the snap will be released to the input channel. If kept empty, the channel will
+          be auto-selected base on the current branch. E.g. if the current branch is
+          master or main, the snap will be released to latest/edge; otherwise, the snap will
+          be released to <branch-name>/edge.
+        default: ''
+        required: false
+        type: string
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish Snap
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: snap-artifact
+      - id: get-snap-name
+        run: echo "SNAP_FILE=$(ls *.snap)" >> $GITHUB_OUTPUT
+      - env:
+          REF: ${{ github.ref_name }}
+          CHANNEL: ${{ inputs.channel == '' }}
+          BOOL: ${{ contains(fromJSON('["main", "master"]'), github.ref_name) }}
+        run:
+          echo $REF
+          echo $CHANNEL
+          echo $BOOL
+      - name: Release snap to latest/edge when pushed to the default branch
+        uses: snapcore/action-publish@v1
+        if: |
+          inputs.channel == '' &&
+          contains(fromJSON('["main", "master"]'), github.ref_name)
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
+          release: latest/edge
+      - name: Release to custom channel when pushed to a versioned branch
+        uses: snapcore/action-publish@v1
+        if: |
+          inputs.channel == '' &&
+          contains(fromJSON('["main", "master"]'), github.ref_name) == false
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
+          release: ${{ github.ref_name }}/edge
+      - name: Release to custom channel with channel input
+        uses: snapcore/action-publish@v1
+        if: inputs.channel != ''
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
+          release: ${{ inputs.channel }}

--- a/.github/workflows/_snap-release.yaml
+++ b/.github/workflows/_snap-release.yaml
@@ -1,31 +1,16 @@
 on:
   workflow_call:
     inputs:
-      track:
+      channel:
         description: |
-          The track to which charm should be released. This input supports a
-          comma-separated tracks in string format. The channels will be a list of
-          track/risk-level combinations. By default, the snap will be released to
-          channel(s) in the "latest" track.
+          A comma-separated list of channels, to which the snap should be released, in
+          string format. By default, the snap will be released to the "latest/edge" channel.
           Examples:
-          - "latest"
-          - "latest,test,2.9"
+          - "latest/edge"
+          - "latest/edge,latest/candidate,2.9/edge"
         required: false
         type: string
-        default: latest
-      risk-level:
-        description: |
-          The risk level to which charm should be released. Valid inputs are one or
-          a combination (in comma-separated string format) of: "edge", "beta",
-          "candidate", "stable". The channels will be a list of track/risk-level
-          combinations. By default, the snap will be released to channel(s) with
-          "edge" risk level.
-          Examples:
-          - "edge"
-          - "edge,candidate"
-        required: false
-        type: string
-        default: edge
+        default: latest/edge
   workflow_dispatch:
 
 jobs:
@@ -40,40 +25,10 @@ jobs:
           name: snap-artifact
       - id: get-snap-name
         run: echo "SNAP_FILE=$(ls *.snap)" >> $GITHUB_OUTPUT
-      - name: Generate a comma separated list of channels to release the snap to
-        id: get-channels
-        env:
-          TRACKS: ${{ inputs.track }}
-          RISKLEVELS: ${{ inputs.risk-level }}
-        run: |
-          # split comma-separated TRACKS and RISKLEVELS to arrays
-          IFS=',' read -ra track_array <<< "$TRACKS"
-          IFS=',' read -ra risklevel_array <<< "$RISKLEVELS"
-
-          # initalize an empty CHANNELS string. It will hold the combination of every
-          # track and risk-level in comma-separated format
-          CHANNELS=""
-
-          # iterate both arrays to get all possible combinations of tracks and risk-levels
-          for i in "${track_array[@]}"; do
-            for j in "${risklevel_array[@]}"; do
-              if [[ $CHANNELS == "" ]]; then
-                # if CHANNELS is empty, set CHANNELS to the first track/risk-level combination 
-                CHANNELS="$i/$j"
-              else
-                # otherwise, concatenate CHANNELS with a new track/risk-level
-                # combination (with a comma in between)
-                CHANNELS="$CHANNELS,$i/$j"
-              fi
-            done;
-          done
-
-          # set CHANNELS to a github output variable so it can be used in future steps
-          echo "channels=$CHANNELS" >> $GITHUB_OUTPUT
       - name: Release snap to the specified channel
         uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
-          release: ${{ steps.get-channels.outputs.channels }}
+          release: ${{ inputs.channel }}

--- a/.github/workflows/_snap-release.yaml
+++ b/.github/workflows/_snap-release.yaml
@@ -3,19 +3,29 @@ on:
     inputs:
       track:
         description: |
-          The track to which charm should be released. By default, the latest track
-          will be used.
-        default: latest
+          The track to which charm should be released. This input supports a
+          comma-separated tracks in string format. The channels will be a list of
+          track/risk-level combinations. By default, the snap will be released to
+          channel(s) in the "latest" track.
+          Examples:
+          - "latest"
+          - "latest,test,2.9"
         required: false
         type: string
+        default: latest
       risk-level:
         description: |
-          The risk level of the channel to which charm should be released. Valid
-          inputs are: edge, beta, candidate, stable. By default, the snap will be
-          released to a channel with "edge" risk level. 
-        default: edge
+          The risk level to which charm should be released. Valid inputs are one or
+          a combination (in comma-separated string format) of: "edge", "beta",
+          "candidate", "stable". The channels will be a list of track/risk-level
+          combinations. By default, the snap will be released to channel(s) with
+          "edge" risk level.
+          Examples:
+          - "edge"
+          - "edge,candidate"
         required: false
         type: string
+        default: edge
   workflow_dispatch:
 
 jobs:
@@ -30,10 +40,40 @@ jobs:
           name: snap-artifact
       - id: get-snap-name
         run: echo "SNAP_FILE=$(ls *.snap)" >> $GITHUB_OUTPUT
+      - name: Generate a comma separated list of channels to release the snap to
+        id: get-channels
+        env:
+          TRACKS: ${{ inputs.track }}
+          RISKLEVELS: ${{ inputs.risk-level }}
+        run: |
+          # split comma-separated TRACKS and RISKLEVELS to arrays
+          IFS=',' read -ra track_array <<< "$TRACKS"
+          IFS=',' read -ra risklevel_array <<< "$RISKLEVELS"
+
+          # initalize an empty CHANNELS string. It will hold the combination of every
+          # track and risk-level in comma-separated format
+          CHANNELS=""
+
+          # iterate both arrays to get all possible combinations of tracks and risk-levels
+          for i in "${track_array[@]}"; do
+            for j in "${risklevel_array[@]}"; do
+              if [[ $CHANNELS == "" ]]; then
+                # if CHANNELS is empty, set CHANNELS to the first track/risk-level combination 
+                CHANNELS="$i/$j"
+              else
+                # otherwise, concatenate CHANNELS with a new track/risk-level
+                # combination (with a comma in between)
+                CHANNELS="$CHANNELS,$i/$j"
+              fi
+            done;
+          done
+
+          # set CHANNELS to a github output variable so it can be used in future steps
+          echo "channels=$CHANNELS" >> $GITHUB_OUTPUT
       - name: Release snap to the specified channel
         uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: ${{ steps.get-snap-name.outputs.SNAP_FILE }}
-          release: ${{ inputs.track }}/${{ inputs.risk-level }}
+          release: ${{ steps.get-channels.outputs.channels }}

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -32,7 +32,9 @@ on:
         default: "3.10"
       tox-version:
         required: false
-        description: "Tox version, which should be used, e.g. `<4`"
+        description: |
+          Tox version, which should be used, e.g. `<4`. If not specified, the
+          latest version of tox will be installed.
         type: string
         default: ""
       working-directory:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -25,7 +25,8 @@ on:
         default: "."
       snapcraft:
         required: false
-        description: "Flag if snap is tested."
+        description: |
+          Flag if snap is tested. If set to true, snapcraft will be installed.
         type: boolean
         default: false
       timeout-minutes:
@@ -36,7 +37,7 @@ on:
       commands:
         required: true
         description: |
-          Command to run functional test in strategies. It accepts a stringified list
+          Command to run functional tests in strategies. It accepts a stringified list
           of commands, which allows you to run multiple tests with different parameters.
           This is a required input field.
           Examples:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,7 +15,9 @@ on:
         default: "3.10"
       tox-version:
         required: false
-        description: "Tox version, which should be used, e.g. `<4`"
+        description: |
+          Tox version, which should be used, e.g. `<4`. If not specified, the
+          latest version of tox will be installed.
         type: string
         default: ""
       working-directory:

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -1,31 +1,16 @@
 on:
   workflow_call:
     inputs:
-      track:
+      channel:
         description: |
-          The track to which charm should be released. This input supports a
-          comma-separated tracks in string format. The channels will be a list of
-          track/risk-level combinations. By default, the snap will be released to
-          channel(s) in the "latest" track.
+          A comma-separated list of channels, to which the snap should be released, in
+          string format. By default, the snap will be released to the "latest/edge" channel.
           Examples:
-          - "latest"
-          - "latest,test,2.9"
+          - "latest/edge"
+          - "latest/edge,latest/candidate,2.9/edge"
         required: false
         type: string
-        default: latest
-      risk-level:
-        description: |
-          The risk level to which charm should be released. Valid inputs are one or
-          a combination (in comma-separated string format) of: "edge", "beta",
-          "candidate", "stable". The channels will be a list of track/risk-level
-          combinations. By default, the snap will be released to channel(s) with
-          "edge" risk level.
-          Examples:
-          - "edge"
-          - "edge,candidate"
-        required: false
-        type: string
-        default: edge
+        default: latest/edge
       python-version-unit:
         required: true
         description: "Python version"
@@ -48,13 +33,14 @@ on:
         default: "."
       snapcraft:
         required: false
-        description: "Flag if snap is tested."
+        description: |
+          Flag if snap is tested. If set to true, snapcraft will be installed.
         type: boolean
         default: true
       commands:
         required: true
         description: |
-          Command to run functional test in strategies. It accepts a stringified list
+          Command to run functional tests in strategies. It accepts a stringified list
           of commands, which allows you to run multiple tests with different parameters.
           This is a required input field.
           Examples:
@@ -65,7 +51,7 @@ on:
         type: string
       timeout-minutes:
         required: false
-        description: "Configurable timeout limit for functional test job"
+        description: "Configurable timeout limit for functional tests job"
         type: number
         default: 60
       # actions-operator
@@ -111,5 +97,4 @@ jobs:
     needs: build
     secrets: inherit
     with:
-      track: ${{ inputs.track }}
-      risk-level: ${{ inputs.risk-level }}
+      channel: ${{ inputs.channel }}

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -1,0 +1,99 @@
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: |
+          The channel to which charm should be released. If specified (non-empty string),
+          the snap will be released to the input channel. If kept empty, the channel will
+          be auto-selected base on the current branch. E.g. if the current branch is
+          master or main, the snap will be released to latest/edge; otherwise, the snap will
+          be released to <branch-name>/edge.
+        default: ''
+        required: false
+        type: string
+      python-version-unit:
+        required: true
+        description: "Python version"
+        type: string
+        default: "['3.8', '3.10']"
+      python-version-func:
+        required: true
+        description: "Python version"
+        type: string
+        default: "3.10"
+      tox-version:
+        required: false
+        description: "Tox version, which should be used, e.g. `<4`"
+        type: string
+        default: ""
+      working-directory:
+        required: false
+        description: "To change working directory"
+        type: string
+        default: "."
+      snapcraft:
+        required: false
+        description: "Flag if snap is tested."
+        type: boolean
+        default: true
+      commands:
+        required: true
+        description: |
+          Command to run functional test in strategies. It accepts a stringified list
+          of commands, which allows you to run multiple tests with different parameters.
+          This is a required input field.
+          Examples:
+          - "['make functional']"
+          - "['FUNC_ARGS="--series jammy" make functional',
+             'FUNC_ARGS="--series focal" make functional']"
+          - "['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']"
+        type: string
+      timeout-minutes:
+        required: false
+        description: "Configurable timeout limit for functional test job"
+        type: number
+        default: 60
+      # actions-operator
+      provider:
+        required: false
+        type: string
+        default: "lxd"
+      nested-containers:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  lint-unit:
+    uses: ./.github/workflows/_lint-unit.yaml
+    secrets: inherit
+    with:
+      python-version: ${{ inputs.python-version-unit }}
+      tox-version: ${{ inputs.tox-version }}
+      working-directory: ${{ inputs.working-directory }}
+
+  func:
+    uses: ./.github/workflows/_func.yaml
+    needs: lint-unit
+    secrets: inherit
+    with:
+      python-version: ${{ inputs.python-version-func }}
+      tox-version: ${{ inputs.tox-version }}
+      working-directory: ${{ inputs.working-directory }}
+      timeout-minutes: ${{ inputs.timeout-minutes }}
+      snapcraft: ${{ inputs.snapcraft }}
+      commands: ${{ inputs.commands }}
+      provider: ${{ inputs.provider }}
+      nested-containers: ${{ inputs.nested-containers }}
+
+  build:
+    uses: ./.github/workflows/_snap-build.yaml
+    needs: func
+    secrets: inherit
+  
+  release-snap:
+    uses: ./.github/workflows/_snap-release.yaml
+    needs: build
+    secrets: inherit
+    with:
+      channel: ${{ inputs.channel }}

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -23,7 +23,9 @@ on:
         default: "3.10"
       tox-version:
         required: false
-        description: "Tox version, which should be used, e.g. `<4`"
+        description: |
+          Tox version, which should be used, e.g. `<4`. If not specified, the
+          latest version of tox will be installed.
         type: string
         default: ""
       working-directory:

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -3,19 +3,29 @@ on:
     inputs:
       track:
         description: |
-          The track to which charm should be released. By default, the latest track
-          will be used.
-        default: latest
+          The track to which charm should be released. This input supports a
+          comma-separated tracks in string format. The channels will be a list of
+          track/risk-level combinations. By default, the snap will be released to
+          channel(s) in the "latest" track.
+          Examples:
+          - "latest"
+          - "latest,test,2.9"
         required: false
         type: string
+        default: latest
       risk-level:
         description: |
-          The risk level of the channel to which charm should be released. Valid
-          inputs are: edge, beta, candidate, stable. By default, the snap will be
-          released to a channel with "edge" risk level. 
-        default: edge
+          The risk level to which charm should be released. Valid inputs are one or
+          a combination (in comma-separated string format) of: "edge", "beta",
+          "candidate", "stable". The channels will be a list of track/risk-level
+          combinations. By default, the snap will be released to channel(s) with
+          "edge" risk level.
+          Examples:
+          - "edge"
+          - "edge,candidate"
         required: false
         type: string
+        default: edge
       python-version-unit:
         required: true
         description: "Python version"

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -1,14 +1,19 @@
 on:
   workflow_call:
     inputs:
-      channel:
+      track:
         description: |
-          The channel to which charm should be released. If specified (non-empty string),
-          the snap will be released to the input channel. If kept empty, the channel will
-          be auto-selected base on the current branch. E.g. if the current branch is
-          master or main, the snap will be released to latest/edge; otherwise, the snap will
-          be released to <branch-name>/edge.
-        default: ''
+          The track to which charm should be released. By default, the latest track
+          will be used.
+        default: latest
+        required: false
+        type: string
+      risk-level:
+        description: |
+          The risk level of the channel to which charm should be released. Valid
+          inputs are: edge, beta, candidate, stable. By default, the snap will be
+          released to a channel with "edge" risk level. 
+        default: edge
         required: false
         type: string
       python-version-unit:
@@ -96,4 +101,5 @@ jobs:
     needs: build
     secrets: inherit
     with:
-      channel: ${{ inputs.channel }}
+      track: ${{ inputs.track }}
+      risk-level: ${{ inputs.risk-level }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BootStack GitHub actions
 
-These actions is meant to be used for unifying lint, unit and functional tests,
+These actions are meant to be used for unifying lint, unit and functional tests,
 charm and snap releases, and sonar integration in GitHub workflows. At the same time,
 workflows that can be directly used will also be found in this repo.
 
@@ -9,25 +9,9 @@ workflows that can be directly used will also be found in this repo.
 ## Charm release workflow
 
 ## Snap release workflow
-This workflow builds and releases snap to the Snap Store after passing lint, unit and
-functional tests. The triggering workflow (from the source repo) can specify track(s)
-and risk level(s) as inputs when calling the reuable workflow to release the snap to the
-proper channel(s). If multiple tracks or risk levels are passed in, the channels will
-be calculated as a list of all combinations of track/risk-level.
-
-Example:
-If the following values are specified for `track` and `risk-level`:
-```
-track: latest, test
-risk-level: edge, candidate
-```
-then the snap will be released to all of the following channels:
-```
-latest/edge
-latest/candidate
-test/edge
-test/candidate
-```
+This workflow builds and releases a snap to the Snap Store after passing lint, unit and
+functional tests. The triggering workflow (from the source repo) can specify one or multiple
+channel(s) as an input when calling the reusable workflow to properly release the snap.
 
 ## Pull request workflow
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # BootStack GitHub actions
 
-These actions is meant to be used for unifying lint, unit and functional tests in GitHub
-workflows. At the same time, workflows that can be directly used will also be found in
-this repo.
+These actions is meant to be used for unifying lint, unit and functional tests,
+charm and snap releases, and sonar integration in GitHub workflows. At the same time,
+workflows that can be directly used will also be found in this repo.
 
 ## Repo configuration workflow
 
 ## Charm release workflow
+
+## Snap release workflow
+This workflow builds and releases snap to the Snap Store after passing lint, unit and
+functional tests. It supports both manual channel selection (via input) and automatic
+channel selection (base on the branch name), which covers the most-common needs for
+snap releases.
 
 ## Pull request workflow
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,24 @@ workflows that can be directly used will also be found in this repo.
 
 ## Snap release workflow
 This workflow builds and releases snap to the Snap Store after passing lint, unit and
-functional tests. The triggering workflow (from the source repo) can specify track
-and risk level as inputs when calling the reuable workflow to release the snap to a
-proper channel.
+functional tests. The triggering workflow (from the source repo) can specify track(s)
+and risk level(s) as inputs when calling the reuable workflow to release the snap to the
+proper channel(s). If multiple tracks or risk levels are passed in, the channels will
+be calculated as a list of all combinations of track/risk-level.
+
+Example:
+If the following values are specified for `track` and `risk-level`:
+```
+track: latest, test
+risk-level: edge, candidate
+```
+then the snap will be released to all of the following channels:
+```
+latest/edge
+latest/candidate
+test/edge
+test/candidate
+```
 
 ## Pull request workflow
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ workflows that can be directly used will also be found in this repo.
 
 ## Snap release workflow
 This workflow builds and releases snap to the Snap Store after passing lint, unit and
-functional tests. It supports both manual channel selection (via input) and automatic
-channel selection (base on the branch name), which covers the most-common needs for
-snap releases.
+functional tests. The triggering workflow (from the source repo) can specify track
+and risk level as inputs when calling the reuable workflow to release the snap to a
+proper channel.
 
 ## Pull request workflow
 


### PR DESCRIPTION
This PR adds workflows to automate snap builds and releases. The added workflows build and release snap to the Snap Store after passing lint, unit and functional tests. The triggering workflow (from the source repo) can specify one or multiple channel(s) as input when calling the reusable workflow to properly release the snap.