### PR TITLE
Add missing juju-channel input options and edit tests

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -54,6 +54,10 @@ on:
              'FUNC_ARGS="--series focal" make functional']"
           - "['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']"
         type: string
+      juju-channel:
+        required: false
+        type: string
+        default: "2.9/stable"
       # actions-operator
       provider:
         required: false

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -48,6 +48,10 @@ on:
              'FUNC_ARGS="--series focal" make functional']"
           - "['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']"
         type: string
+      juju-channel:
+        required: false
+        type: string
+        default: "2.9/stable"
       # actions-operator
       provider:
         required: false

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -56,6 +56,10 @@ on:
         description: "Configurable timeout limit for functional tests job"
         type: number
         default: 60
+      juju-channel:
+        required: false
+        type: string
+        default: "2.9/stable"
       # actions-operator
       provider:
         required: false

--- a/.github/workflows/test-func.yaml
+++ b/.github/workflows/test-func.yaml
@@ -19,6 +19,7 @@ jobs:
       timeout-minutes: 120
       provider: "lxd"
       nested-containers: true
+      juju-channel: "2.9/stable"
 
   snap-func:
     uses: ./.github/workflows/_func.yaml

--- a/.github/workflows/test-pull-request.yaml
+++ b/.github/workflows/test-pull-request.yaml
@@ -20,6 +20,7 @@ jobs:
       tox-version: "<4"
       working-directory: ./tests/test_charm_repo
       commands: "['FUNC_ARGS=\"--series jammy\" make functional']"
+      juju-channel: "2.9/stable"
 
   snap-pr:
     uses: ./.github/workflows/pull-request.yaml


### PR DESCRIPTION
In the previous PR #29 , `juju-channel` input option is used by `pull-request.yaml`, `charm-release.yaml`, and `snap-release.yaml` to call functional tests (`_func.yaml`). However, there's no `juju-channel` defined in those three file's `workflow_call` to read in user's input. This PR fixes this issue and added test for this input option.