### PR TITLE
Initialize lxd before packing charm in release workflow

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -57,8 +57,18 @@ jobs:
       - name: Unpack Artifact
         if: ${{ inputs.artifact != '' }}
         run: sudo apt-get update && sudo apt-get install tar && tar xf artifact.tar.gz
-      - name: Initialize lxd
-        run: sudo lxd init --auto
+      - name: Initialize lxd  # This should dropped once it's implemented on charming-actions itself.
+        if: ${{ inputs.destructive-mode == 'false' }}
+        run: |
+          sudo lxd init --auto
+          # The following is needed to fix network error when creating new base instance on lxd
+          sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+          lxc network set lxdbr0 ipv6.address none
+          sudo usermod -a -G lxd $USER
+          if [[ $(cat /etc/os-release | grep VERSION_CODENAME) == *"jammy"* ]]; then
+            sudo iptables -F FORWARD
+            sudo iptables -P FORWARD ACCEPT
+          fi
       - name: Upload charm to CharmHub
         uses: canonical/charming-actions/upload-charm@2.4.0
         with:

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -57,6 +57,8 @@ jobs:
       - name: Unpack Artifact
         if: ${{ inputs.artifact != '' }}
         run: sudo apt-get update && sudo apt-get install tar && tar xf artifact.tar.gz
+      - name: Initialize lxd
+        run: sudo lxd init --auto
       - name: Upload charm to CharmHub
         uses: canonical/charming-actions/upload-charm@2.4.0
         with:


### PR DESCRIPTION
This is required when charmcraft tries to launch an lxd instance to build the charm.