### PR TITLE
Add option to run additional commands before charm build

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -35,6 +35,13 @@ on:
           Can be used to turn off destructive mode while building.
           This is useful when building on other architectures/bases than the one
           of the runner.
+      build-preconfiguration:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Commands to run before charmcraft pack. Can be useful in cases where packages
+          need to be bundled at charm build time, or any other preconfiguration.
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -69,6 +76,8 @@ jobs:
             sudo iptables -F FORWARD
             sudo iptables -P FORWARD ACCEPT
           fi
+      - name: Build preconfiguration
+        run: ${{ inputs.build-preconfiguration }}
       - name: Upload charm to CharmHub
         uses: canonical/charming-actions/upload-charm@2.4.0
         with:


### PR DESCRIPTION
A use case for this is when packages need to be bundled at charm build time ([example](https://github.com/canonical/charm-userdir-ldap/blob/54899932651c97b2f4b0fc84927397b0de942f50/Makefile#L45))