### PR TITLE
Use recent release of charming actions to support multiple release

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -70,9 +70,7 @@ jobs:
             sudo iptables -P FORWARD ACCEPT
           fi
       - name: Upload charm to CharmHub
-        # Using the version of charming-actions that supports release of multiple builds at once.
-        # The commit hash should be replaced by release version after the next release of charming-actions.
-        uses: canonical/charming-actions/upload-charm@0953ad46cdd8363b3c9c923793c467c5d948ce7f
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -70,7 +70,9 @@ jobs:
             sudo iptables -P FORWARD ACCEPT
           fi
       - name: Upload charm to CharmHub
-        uses: canonical/charming-actions/upload-charm@2.4.0
+        # Using the version of charming-actions that supports release of multiple builds at once.
+        # The commit hash should be replaced by release version after the next release of charming-actions.
+        uses: canonical/charming-actions/upload-charm@0953ad46cdd8363b3c9c923793c467c5d948ce7f
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The [feature](https://github.com/canonical/charming-actions/commit/0953ad46cdd8363b3c9c923793c467c5d948ce7f) to release multiple builds at once is needed for [charm-juju-backup-all](https://github.com/canonical/charm-juju-backup-all/blob/b93302531237e66743e55343612b3511f60549dc/charmcraft.yaml#L12-L29) for it's release pipeline to work completely.